### PR TITLE
fix: support `androidRelativePath` on Android 9 and below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Migrate Android Gradle config to Gradle 9.1.0, AGP 9.0.1, and Kotlin Gradle plugin 2.3.20.
 * Migrate Android app and plugin Gradle config to AGP 9 Built-in Kotlin.
 * Fix Android Java 8 obsolete source/target warnings by setting Android Java/Kotlin targets to 17 (#31).
+* Fix `androidRelativePath` being ignored on Android 9 and below (#26).
 * Raise iOS platform from 11.0 to 13.0.
 * Remove the example app's `fluttertoast` dependency and use Flutter `SnackBar` messages instead.
 * Update example dependency overrides needed for Flutter 3.44 and Dart 3.12 compatibility.

--- a/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/LegacyRelativePathResolver.kt
+++ b/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/LegacyRelativePathResolver.kt
@@ -1,0 +1,76 @@
+package com.mhz.savegallery.saver_gallery
+
+import android.os.Environment
+
+internal data class LegacyRelativePath(
+    val publicDirectory: String,
+    val childPath: String?
+)
+
+internal object LegacyRelativePathResolver {
+    private val publicDirectoryAliases = mapOf(
+        "DCIM" to Environment.DIRECTORY_DCIM,
+        "Documents" to Environment.DIRECTORY_DOCUMENTS,
+        "Download" to Environment.DIRECTORY_DOWNLOADS,
+        "Downloads" to Environment.DIRECTORY_DOWNLOADS,
+        "Movies" to Environment.DIRECTORY_MOVIES,
+        "Music" to Environment.DIRECTORY_MUSIC,
+        "Pictures" to Environment.DIRECTORY_PICTURES
+    )
+
+    fun resolve(relativePath: String, mimeType: String?): LegacyRelativePath {
+        val defaultDirectory = defaultDirectoryForMimeType(mimeType)
+        val normalizedPath = normalize(relativePath)
+
+        if (normalizedPath.isEmpty()) {
+            return LegacyRelativePath(defaultDirectory, null)
+        }
+
+        val segments = normalizedPath.split("/")
+        val publicDirectory = publicDirectoryAliases[segments.first()]
+
+        return if (publicDirectory != null) {
+            LegacyRelativePath(
+                publicDirectory = publicDirectory,
+                childPath = segments.drop(1).joinToString("/").ifEmpty { null }
+            )
+        } else {
+            LegacyRelativePath(
+                publicDirectory = defaultDirectory,
+                childPath = normalizedPath
+            )
+        }
+    }
+
+    private fun normalize(relativePath: String): String {
+        val path = relativePath.trim().replace('\\', '/')
+
+        require(!path.startsWith("/")) {
+            "androidRelativePath must be relative"
+        }
+        require(!Regex("^[A-Za-z]:").containsMatchIn(path)) {
+            "androidRelativePath must be relative"
+        }
+
+        val normalizedPath = path.trim('/')
+        if (normalizedPath.isEmpty()) {
+            return ""
+        }
+
+        val segments = normalizedPath.split("/")
+        require(segments.none { it.isEmpty() || it == "." || it == ".." }) {
+            "androidRelativePath contains unsafe path segments"
+        }
+
+        return normalizedPath
+    }
+
+    private fun defaultDirectoryForMimeType(mimeType: String?): String {
+        return when {
+            mimeType?.startsWith("image/") == true -> Environment.DIRECTORY_PICTURES
+            mimeType?.startsWith("video/") == true -> Environment.DIRECTORY_MOVIES
+            mimeType?.startsWith("audio/") == true -> Environment.DIRECTORY_MUSIC
+            else -> Environment.DIRECTORY_DOWNLOADS
+        }
+    }
+}

--- a/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaverDelegateDefault.kt
+++ b/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaverDelegateDefault.kt
@@ -155,7 +155,7 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                 }
                 notifyGallery(fileUri)
                 SaveResultModel(fileUri.toString().isNotEmpty(), null).toHashMap()
-            } catch (e: IOException) {
+            } catch (e: Exception) {
                 e.printStackTrace()
                 SaveResultModel(false, "Failed to save image: ${e.message}").toHashMap()
             }
@@ -194,7 +194,7 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                 }
                 notifyGallery(fileUri)
                 SaveResultModel(fileUri.toString().isNotEmpty(), null).toHashMap()
-            } catch (e: IOException) {
+            } catch (e: Exception) {
                 e.printStackTrace()
                 SaveResultModel(false, "Failed to save file: ${e.message}").toHashMap()
             }
@@ -212,7 +212,6 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
     @SuppressLint("InlinedApi")
     private fun generateFileUri(fileName: String, relativePath: String): Uri {
         val mimeType = getMIMEType(fileName.substringAfterLast('.', ""))
-        val isVideo = mimeType?.startsWith("video")==true
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             // Determine the type of content URI based on MIME type.
             val contentUri = when {
@@ -238,20 +237,9 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
 
             return context.contentResolver.insert(contentUri, contentValues)
                 ?: throw IOException("Failed to create Media URI for $fileName")
-        }else{
-            val storePath =
-                Environment.getExternalStoragePublicDirectory(when {
-                    isVideo -> Environment.DIRECTORY_MOVIES
-                    else -> Environment.DIRECTORY_PICTURES
-                }).absolutePath
-            val appDir = File(storePath).apply {
-                if (!exists()) {
-                    mkdir()
-                }
-            }
-            val file =
-                File(appDir, fileName)
-            return Uri.fromFile(file)
+        } else {
+            val targetDirectory = resolveLegacyTargetDirectory(relativePath, mimeType)
+            return Uri.fromFile(File(targetDirectory, fileName))
         }
     }
 
@@ -286,22 +274,30 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                 false
             }
         } else {
-            val mimeType = getMIMEType(fileName.substringAfterLast('.', ""))
-            val isVideo = mimeType?.startsWith("video")==true
-            val storePath =
-                Environment.getExternalStoragePublicDirectory(when {
-                    isVideo -> Environment.DIRECTORY_MOVIES
-                    else -> Environment.DIRECTORY_PICTURES
-                }).absolutePath
-            val appDir = File(storePath).apply {
-                if (!exists()) {
-                    mkdir()
-                }
+            return try {
+                val mimeType = getMIMEType(fileName.substringAfterLast('.', ""))
+                val targetDirectory = resolveLegacyTargetDirectory(relativePath, mimeType)
+                File(targetDirectory, fileName).exists()
+            } catch (e: Exception) {
+                e.printStackTrace()
+                false
             }
-            val file =
-                File(appDir, fileName)
-            return file.exists()
         }
+    }
+
+    private fun resolveLegacyTargetDirectory(relativePath: String, mimeType: String?): File {
+        val resolvedPath = LegacyRelativePathResolver.resolve(relativePath, mimeType)
+        val publicDirectory = Environment.getExternalStoragePublicDirectory(resolvedPath.publicDirectory)
+        val targetDirectory = resolvedPath.childPath?.let { File(publicDirectory, it) } ?: publicDirectory
+
+        if (!targetDirectory.exists() && !targetDirectory.mkdirs()) {
+            throw IOException("Failed to create directory ${targetDirectory.absolutePath}")
+        }
+        if (!targetDirectory.isDirectory) {
+            throw IOException("Path is not a directory: ${targetDirectory.absolutePath}")
+        }
+
+        return targetDirectory
     }
 
     /**

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -79,9 +79,7 @@ class _MyHomePageState extends State<MyHomePage> {
       final deviceInfoPlugin = DeviceInfoPlugin();
       final deviceInfo = await deviceInfoPlugin.androidInfo;
       final sdkInt = deviceInfo.version.sdkInt;
-      statuses = sdkInt < 29
-          ? await Permission.storage.request().isGranted
-          : true;
+      statuses = sdkInt < 29 ? await Permission.storage.request().isGranted : true;
     } else {
       statuses = await Permission.photosAddOnly.request().isGranted;
     }
@@ -91,13 +89,9 @@ class _MyHomePageState extends State<MyHomePage> {
   /// Captures the current screen and saves it as an image in the gallery.
   Future<void> _saveScreen() async {
     try {
-      RenderRepaintBoundary boundary =
-          _globalKey.currentContext!.findRenderObject()
-              as RenderRepaintBoundary;
+      RenderRepaintBoundary boundary = _globalKey.currentContext!.findRenderObject() as RenderRepaintBoundary;
       ui.Image image = await boundary.toImage();
-      ByteData? byteData = await image.toByteData(
-        format: ui.ImageByteFormat.png,
-      );
+      ByteData? byteData = await image.toByteData(format: ui.ImageByteFormat.png);
       if (byteData != null) {
         String picturesPath = "${DateTime.now().millisecondsSinceEpoch}.jpg";
         final result = await SaverGallery.saveImage(
@@ -140,11 +134,11 @@ class _MyHomePageState extends State<MyHomePage> {
         "https://test-1300597023.cos.ap-singapore.myqcloud.com/hyj-doc-flutter-demo-run%20%281%29.gif",
         options: Options(responseType: ResponseType.bytes),
       );
-      String gifPath = "network_gif.gif";
+      String gifPath = "test_image.gif";
       final result = await SaverGallery.saveImage(
         Uint8List.fromList(response.data),
         fileName: gifPath,
-        androidRelativePath: "Pictures/Gifs",
+        androidRelativePath: "Pictures/appName/images",
         skipIfExists: false,
       );
       _showMessage(result.toString());
@@ -157,18 +151,13 @@ class _MyHomePageState extends State<MyHomePage> {
   Future<void> _saveVideo() async {
     try {
       final dir = await getTemporaryDirectory();
-      String savePath =
-          "${dir.path}/${DateTime.now().millisecondsSinceEpoch}.mp4";
-      String fileUrl =
-          "https://test-1300597023.cos.ap-singapore.myqcloud.com/ForBiggerBlazes.mp4";
+      String savePath = "${dir.path}/${DateTime.now().millisecondsSinceEpoch}.mp4";
+      String fileUrl = "https://test-1300597023.cos.ap-singapore.myqcloud.com/ForBiggerBlazes.mp4";
 
       await Dio().download(
         fileUrl,
         savePath,
-        options: Options(
-          sendTimeout: Duration(minutes: 10),
-          receiveTimeout: Duration(minutes: 10),
-        ),
+        options: Options(sendTimeout: Duration(minutes: 10), receiveTimeout: Duration(minutes: 10)),
         onReceiveProgress: (count, total) {
           debugPrint("${(count / total * 100).toStringAsFixed(0)}%");
         },
@@ -193,17 +182,29 @@ class _MyHomePageState extends State<MyHomePage> {
       return;
     }
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) {
-        return;
-      }
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger != null) {
+      _showSnackBar(messenger, info);
+      return;
+    }
 
-      final messenger = ScaffoldMessenger.of(context);
-      messenger
-        ..hideCurrentSnackBar()
-        ..showSnackBar(
-          SnackBar(content: Text(info), behavior: SnackBarBehavior.floating),
-        );
-    });
+    WidgetsBinding.instance
+      ..addPostFrameCallback((_) {
+        if (!mounted) {
+          return;
+        }
+
+        final nextMessenger = ScaffoldMessenger.maybeOf(context);
+        if (nextMessenger != null) {
+          _showSnackBar(nextMessenger, info);
+        }
+      })
+      ..ensureVisualUpdate();
+  }
+
+  void _showSnackBar(ScaffoldMessengerState messenger, String info) {
+    messenger
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(content: Text(info), behavior: SnackBarBehavior.floating));
   }
 }


### PR DESCRIPTION
## Summary

Fix `androidRelativePath` being ignored on Android 9 and below.

On legacy Android storage (`Build.VERSION.SDK_INT < 29`), `SaverDelegateDefault` previously ignored the requested `relativePath` and always wrote images/videos into the top-level public `Pictures` or `Movies` directory. This caused paths like `Pictures/appName/images` to be flattened to `Pictures`.

## Changes

- Add `LegacyRelativePathResolver` for Android legacy external storage.
- Normalize `androidRelativePath` and map known public directory prefixes:
  - `Pictures`
  - `Movies`
  - `Music`
  - `Documents`
  - `Download` / `Downloads`
  - `DCIM`
- Support nested paths such as `Pictures/appName/images`.
- Reject unsafe legacy paths such as absolute paths or `..` traversal.
- Update `SaverDelegateDefault` legacy save flow to create nested target directories with `mkdirs()`.
- Update legacy `skipIfExists` checks to use the same resolved target directory as writes.
- Keep Android 10+ `MediaStore.RELATIVE_PATH` behavior unchanged.
- Update example GIF save path to exercise nested `androidRelativePath`.
- Fix example `SnackBar` display so save results show on the first tap.
- Update CHANGELOG for #26.

## Fixed Issues

- Fixes #26

## Test Result

https://github.com/user-attachments/assets/1fb063b2-ad39-4b60-b981-d17dd7a79da9

