### PR TITLE
Fix iOS parallel save result race (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+
+* Fix iOS parallel save requests overwriting pending results (#30).
 
 ## 5.0.2
 * Require Flutter `>=3.44.0` and Dart `>=3.12.0 <4.0.0`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -56,6 +56,7 @@ class _MyHomePageState extends State<MyHomePage> {
             _buildButton("Save Network Image", _getHttp),
             _buildButton("Save Network Video", _saveVideo),
             _buildButton("Save Gif to Gallery", _saveGif),
+            _buildButton("Save Two Gifs", _saveTwoGifs),
           ],
         ),
       ),
@@ -142,6 +143,33 @@ class _MyHomePageState extends State<MyHomePage> {
         skipIfExists: false,
       );
       _showMessage(result.toString());
+    } catch (e) {
+      _showMessage('Error: $e');
+    }
+  }
+
+  Future<void> _saveTwoGifs() async {
+    try {
+      final response = await Dio().get(
+        "https://test-1300597023.cos.ap-singapore.myqcloud.com/hyj-doc-flutter-demo-run%20%281%29.gif",
+        options: Options(responseType: ResponseType.bytes),
+      );
+      final bytes = Uint8List.fromList(response.data);
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final results = await Future.wait([
+        SaverGallery.saveImage(
+          bytes,
+          fileName: "parallel_${timestamp}_1.gif",
+          skipIfExists: false,
+        ),
+        SaverGallery.saveImage(
+          bytes,
+          fileName: "parallel_${timestamp}_2.gif",
+          skipIfExists: false,
+        ),
+      ]);
+
+      _showMessage(results.toString());
     } catch (e) {
       _showMessage('Error: $e');
     }

--- a/ios/saver_gallery/Sources/saver_gallery/SaverGalleryPlugin.swift
+++ b/ios/saver_gallery/Sources/saver_gallery/SaverGalleryPlugin.swift
@@ -4,8 +4,6 @@ import Photos
 
 public class SaverGalleryPlugin: NSObject, FlutterPlugin {
   let errorMessage = "Failed to save, please check whether the permission is enabled"
-       
-  var result: FlutterResult?;
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "com.fluttercandies/saver_gallery", binaryMessenger: registrar.messenger())
@@ -14,19 +12,23 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
   }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-      self.result = result
       if call.method == "saveImageToGallery" {
         let arguments = call.arguments as? [String: Any] ?? [String: Any]()
-        saveImageToGallery(arguments)
+        saveImageToGallery(arguments, result: result)
       } else if (call.method == "saveFileToGallery") {
         guard let arguments = call.arguments as? [String: Any],
               let path = arguments["filePath"] as? String
-              else { return }
+              else {
+            saveResult(isSuccess: false, error: "Invalid arguments", result: result)
+            return
+        }
         if (isImageFile(fileName: path)) {
-            saveImageAtFileUrl(path)
+            saveImageAtFileUrl(path, result: result)
         } else {
             if (UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(path)) {
-                saveVideo(path)
+                saveVideo(path, result: result)
+            } else {
+                saveResult(isSuccess: false, error: "Unsupported file type", result: result)
             }
         }
       } else if (call.method == "saveFilesToGallery") {
@@ -36,17 +38,20 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
             result(["isSuccess": false, "errorMessage": "Invalid arguments"])
             return 
         }
-        saveFiles(files)
+        saveFiles(files, result: result)
       } else {
         result(FlutterMethodNotImplemented)
       }
     }
 
-    func saveImageToGallery(_ arguments: [String: Any]) {
+    func saveImageToGallery(_ arguments: [String: Any], result: @escaping FlutterResult) {
         guard let imageData = (arguments["image"] as? FlutterStandardTypedData)?.data,
               let quality = arguments["quality"] as? Int,
               let fileName = arguments["fileName"] as? String
-              else { return }
+              else {
+            saveResult(isSuccess: false, error: "Invalid arguments", result: result)
+            return
+        }
 
         let extFromArgs = (arguments["extension"] as? String)?.lowercased()
         let extFromFileName = URL(fileURLWithPath: fileName).pathExtension.lowercased()
@@ -73,20 +78,31 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && imageIds.count > 0) {
-                    self.saveResult(isSuccess: true)
+                    self.saveResult(isSuccess: true, result: result)
                 } else {
-                    self.saveResult(isSuccess: false, error: self.errorMessage)
+                    self.saveResult(isSuccess: false, error: self.errorMessage, result: result)
                 }
             }
         })
     }
 
-    func saveFiles(_ files: [[String: String]]) {
+    func saveFiles(_ files: [[String: String]], result: @escaping FlutterResult) {
         var successCount = 0
         var failureCount = 0
         var errors: [String] = []
         let totalFiles = files.count
         var processedCount = 0
+
+        if totalFiles == 0 {
+            saveResult(isSuccess: false, error: "File list is empty", result: result)
+            return
+        }
+
+        func finishIfNeeded() {
+            if processedCount == totalFiles {
+                self.saveBatchResult(successCount: successCount, failureCount: failureCount, errors: errors, result: result)
+            }
+        }
         
         for fileData in files {
             guard let filePath = fileData["filePath"],
@@ -94,6 +110,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                 processedCount += 1
                 failureCount += 1
                 errors.append("Invalid file data")
+                finishIfNeeded()
                 continue
             }
             
@@ -111,9 +128,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                             errors.append("\(fileName): \(error?.localizedDescription ?? "Unknown error")")
                         }
                         
-                        if processedCount == totalFiles {
-                            self.saveBatchResult(successCount: successCount, failureCount: failureCount, errors: errors)
-                        }
+                        finishIfNeeded()
                     }
                 })
             } else if UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(filePath) {
@@ -130,24 +145,19 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                             errors.append("\(fileName): \(error?.localizedDescription ?? "Unknown error")")
                         }
                         
-                        if processedCount == totalFiles {
-                            self.saveBatchResult(successCount: successCount, failureCount: failureCount, errors: errors)
-                        }
+                        finishIfNeeded()
                     }
                 })
             } else {
                 processedCount += 1
                 failureCount += 1
                 errors.append("\(fileName): Unsupported file type")
-                
-                if processedCount == totalFiles {
-                    self.saveBatchResult(successCount: successCount, failureCount: failureCount, errors: errors)
-                }
+                finishIfNeeded()
             }
         }
     }
 
-    func saveVideo(_ path: String) {
+    func saveVideo(_ path: String, result: @escaping FlutterResult) {
         var videoIds: [String] = []
 
         PHPhotoLibrary.shared().performChanges( {
@@ -158,15 +168,15 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && videoIds.count > 0) {
-                    self.saveResult(isSuccess: true)
+                    self.saveResult(isSuccess: true, result: result)
                 } else {
-                    self.saveResult(isSuccess: false, error: self.errorMessage)
+                    self.saveResult(isSuccess: false, error: self.errorMessage, result: result)
                 }
             }
         })
     }
 
-    func saveImageAtFileUrl(_ url: String) {
+    func saveImageAtFileUrl(_ url: String, result: @escaping FlutterResult) {
   
         var imageIds: [String] = []
 
@@ -178,31 +188,22 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && imageIds.count > 0) {
-                    self.saveResult(isSuccess: true)
+                    self.saveResult(isSuccess: true, result: result)
                 } else {
-                    self.saveResult(isSuccess: false, error: self.errorMessage)
+                    self.saveResult(isSuccess: false, error: self.errorMessage, result: result)
                 }
             }
         })
     }
 
-    /// finish saving，if has error，parameters error will not nill
-    @objc func didFinishSavingImage(image: UIImage, error: NSError?, contextInfo: UnsafeMutableRawPointer?) {
-        saveResult(isSuccess: error == nil, error: error?.description)
-    }
-
-    @objc func didFinishSavingVideo(videoPath: String, error: NSError?, contextInfo: UnsafeMutableRawPointer?) {
-        saveResult(isSuccess: error == nil, error: error?.description)
-    }
-
-    func saveResult(isSuccess: Bool, error: String? = nil) {
+    func saveResult(isSuccess: Bool, error: String? = nil, result: FlutterResult) {
         var saveResult = SaveResultModel()
-        saveResult.isSuccess = error == nil
+        saveResult.isSuccess = isSuccess
         saveResult.errorMessage = error?.description
-        result?(saveResult.toDic())
+        result(saveResult.toDic())
     }
 
-    func saveBatchResult(successCount: Int, failureCount: Int, errors: [String]) {
+    func saveBatchResult(successCount: Int, failureCount: Int, errors: [String], result: FlutterResult) {
         var saveResult = SaveResultModel()
         if failureCount == 0 {
             saveResult.isSuccess = true
@@ -212,7 +213,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
             let errorMessage = "Saved \(successCount) files, failed \(failureCount) files. Errors: \(errors.joined(separator: "; "))"
             saveResult.errorMessage = errorMessage
         }
-        result?(saveResult.toDic())
+        result(saveResult.toDic())
     }
 
     func isImageFile(fileName: String) -> Bool {


### PR DESCRIPTION
## Summary

Fix iOS save requests hanging or returning incorrect results when save methods are called in parallel.

The iOS plugin previously stored the pending `FlutterResult` in a shared instance property. When multiple save operations were started before the first one completed, a later request could overwrite the earlier callback. This could leave the first Dart `Future` hanging indefinitely or cause results to be delivered to the wrong request.

## Changes

- Remove the shared iOS `FlutterResult` instance state.
- Pass the current `FlutterResult` through each save flow:
  - `saveImageToGallery`
  - `saveFileToGallery`
  - `saveFilesToGallery`
- Ensure each async `PHPhotoLibrary.performChanges` completion resolves only its own request.
- Return failed save results instead of silently returning for invalid iOS arguments.
- Return failed save result for unsupported iOS file types.
- Return failed batch result for empty iOS file lists.
- Add an example `Save Two Gifs` button to manually trigger parallel save calls with `Future.wait`.
- Update CHANGELOG for #30.

## Fixed Issues

- Fixes #30

## Test result

https://github.com/user-attachments/assets/86bd134d-4aa9-4e20-8f51-e4a8a8f54a6b

