### PR TITLE
feat: Add cross-platform album paths and return saved media URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-* **Breaking change**: Replace `androidRelativePath` with `albumPath`, enabling cross-platform album hierarchy support on Android and iOS (Refs #23).
+* **Breaking change**: Replace `androidRelativePath` with `albumPath`, enabling cross-platform album hierarchy support on Android and iOS (#23).
 * Add iOS PhotoKit folder hierarchy support for nested `albumPath` values.
+* Return saved URI(s) after saving (#23).
 
 ## 5.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* **Breaking change**: Replace `androidRelativePath` with `albumPath`, enabling cross-platform album hierarchy support on Android and iOS (Refs #23).
+* Add iOS PhotoKit folder hierarchy support for nested `albumPath` values.
+
 ## 5.0.3
 
 * Fix iOS parallel save requests overwriting pending results (#30).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The `saver_gallery` plugin enables you to save images and other media files (suc
 
 - Save images of various formats (`png`, `jpg`, `gif`, etc.) to the gallery.
 - Save video and other media files to the gallery.
+- Save media into named albums on Android and iOS.
 - **Batch save multiple images or files at once.**
 - Handle conditional saving with the `skipIfExists` parameter.
 - Compatible with Android, iOS, and HarmonyOS platforms.
@@ -185,7 +186,7 @@ _saveGif() async {
     Uint8List.fromList(response.data),
     quality: 60,
     fileName: imageName,
-    androidRelativePath: "Pictures/appName/images",
+    albumPath: "appName/images",
     skipIfExists: false,
   );
 
@@ -197,9 +198,41 @@ _saveGif() async {
 **Explanation:**
 
 - `quality`: Set the image quality (0-100) for compressing images. This only applies to `jpg` format.
-- `fileName`: The name of the file being saved.
-- `androidRelativePath`: Relative path in the Android gallery, e.g., `"Pictures/appName/images"`.
+- `fileName`: The name of the file being saved. This should be a file name, not an album path.
+- `albumPath`: Album hierarchy path for Android and iOS, e.g. `"appName/images"` saves images to `"Pictures/appName/images"` on Android and `appName > images` in iOS Photos.
 - `skipIfExists`: If `true`, skips saving the image if it already exists in the specified path.
+
+---
+
+### Saving to an Album
+
+Use `albumPath` when you want Android and iOS to save into a named album:
+
+```dart
+final result = await SaverGallery.saveImage(
+  imageBytes,
+  fileName: 'album_image.jpg',
+  albumPath: 'MyAlbum',
+  skipIfExists: false,
+);
+```
+
+On iOS, `albumPath` creates or reuses a PhotoKit user album. On Android, it maps to the default media directory for the file type, such as `"Pictures/MyAlbum"` for images or `"Movies/MyAlbum"` for videos.
+
+Use nested `albumPath` when you need folder-like organization:
+
+```dart
+final result = await SaverGallery.saveImage(
+  imageBytes,
+  fileName: 'album_image.jpg',
+  albumPath: 'appName/images',
+  skipIfExists: false,
+);
+```
+
+This saves to `Pictures/appName/images` on Android and `appName > images` in iOS Photos. The last segment is the iOS album; parent segments are iOS folders.
+
+Android public-directory prefixes are also accepted for migration compatibility, for example `albumPath: 'Pictures/appName/images'`. `albumPath` must be a relative album hierarchy path, not an absolute filesystem path.
 
 ---
 
@@ -225,7 +258,7 @@ _saveVideo() async {
     filePath: videoPath,
     skipIfExists: true,
     fileName: 'sample_video.mp4',
-    androidRelativePath: "Movies",
+    albumPath: "appName/videos",
   );
 
   print(result);
@@ -237,7 +270,7 @@ _saveVideo() async {
 - `filePath`: Path to the file being saved.
 - `skipIfExists`: If `true`, skips saving the file if it already exists.
 - `fileName`: Desired name of the file in the gallery.
-- `androidRelativePath`: Relative path in the Android gallery, e.g., `"Movies"`.
+- `albumPath`: Album hierarchy path for Android and iOS. For videos, `"appName/videos"` saves to `"Movies/appName/videos"` on Android and `appName > videos` in iOS Photos.
 
 ---
 
@@ -251,8 +284,8 @@ import 'package:saver_gallery/saver_gallery.dart';
 // Batch save images
 _saveBatchImages() async {
   final images = [
-    SaveImageData(bytes: imageBytes1, fileName: 'image1.jpg'),
-    SaveImageData(bytes: imageBytes2, fileName: 'image2.png'),
+    SaveImageData(bytes: imageBytes1, fileName: 'image1.jpg', albumPath: 'MyAlbum'),
+    SaveImageData(bytes: imageBytes2, fileName: 'image2.png', albumPath: 'MyAlbum'),
   ];
   
   final result = await SaverGallery.saveImages(images, skipIfExists: false);
@@ -262,8 +295,8 @@ _saveBatchImages() async {
 // Batch save files
 _saveBatchFiles() async {
   final files = [
-    SaveFileData(filePath: '/path/to/file1.mp4', fileName: 'video1.mp4'),
-    SaveFileData(filePath: '/path/to/file2.mp4', fileName: 'video2.mp4'),
+    SaveFileData(filePath: '/path/to/file1.mp4', fileName: 'video1.mp4', albumPath: 'MyAlbum'),
+    SaveFileData(filePath: '/path/to/file2.mp4', fileName: 'video2.mp4', albumPath: 'MyAlbum'),
   ];
   
   final result = await SaverGallery.saveFiles(files, skipIfExists: false);

--- a/README.md
+++ b/README.md
@@ -236,6 +236,33 @@ Android public-directory prefixes are also accepted for migration compatibility,
 
 ---
 
+### Saved URI Result
+
+`SaveResult` includes the saved media location returned by the platform:
+
+```dart
+final result = await SaverGallery.saveImage(
+  imageBytes,
+  fileName: 'album_image.jpg',
+  albumPath: 'appName/images',
+  skipIfExists: false,
+);
+
+print(result.savedUri);
+print(result.savedUris);
+```
+
+- `savedUri`: The saved URI for single-file saves.
+- `savedUris`: Saved URIs for batch saves. Single-file saves also mirror `savedUri` into this list.
+- Android 10+ returns `content://...`.
+- Android 9 and below returns `file://...`.
+- iOS returns `ph://...`, based on the Photos asset local identifier.
+- OHOS returns the media library URI from the asset creation dialog.
+
+`savedUri` is a platform location identifier, not a guaranteed filesystem path.
+
+---
+
 ### Saving a File (e.g., Video)
 
 To save other types of files (e.g., videos) to the gallery:

--- a/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaveResult.kt
+++ b/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaveResult.kt
@@ -2,12 +2,16 @@ package com.mhz.savegallery.saver_gallery
 
 class SaveResultModel(
     var isSuccess: Boolean,
-    var errorMessage: String? = null
+    var errorMessage: String? = null,
+    var savedUri: String? = null,
+    var savedUris: List<String> = emptyList()
 ) {
     fun toHashMap(): HashMap<String, Any?> {
         val hashMap = HashMap<String, Any?>()
         hashMap["isSuccess"] = isSuccess
         hashMap["errorMessage"] = errorMessage
+        hashMap["savedUri"] = savedUri
+        hashMap["savedUris"] = if (savedUris.isNotEmpty()) savedUris else savedUri?.let { listOf(it) }.orEmpty()
         return hashMap
     }
 }

--- a/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaverDelegateAndroidT.kt
+++ b/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaverDelegateAndroidT.kt
@@ -1,6 +1,7 @@
 package com.mhz.savegallery.saver_gallery
 
 import android.annotation.SuppressLint
+import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.graphics.Bitmap
@@ -35,8 +36,10 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
     ) {
         mainScope.launch {
             // Check if the file already exists in the gallery, if `skipIfExists` is true.
-            if (skipIfExists && fileExistsInGallery(relativePath, fileName)) {
-                result.success(SaveResultModel(true).toHashMap())
+            val mimeType = getMIMEType(extension) ?: "image/$extension"
+            val existingUri = if (skipIfExists) findExistingUri(relativePath, fileName, mimeType) else null
+            if (skipIfExists && existingUri != null) {
+                result.success(SaveResultModel(true, savedUri = existingUri.toString()).toHashMap())
                 return@launch
             }
 
@@ -49,7 +52,7 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
 
             // Scan and make the saved image visible in the gallery.
             scanUri(context, uri, "image/$extension")
-            result.success(SaveResultModel(isSuccess, if (!isSuccess) "Couldn't save the image" else null).toHashMap())
+            result.success(SaveResultModel(isSuccess, if (!isSuccess) "Couldn't save the image" else null, savedUri = if (isSuccess) uri.toString() else null).toHashMap())
         }
     }
 
@@ -62,17 +65,18 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
     ) {
         mainScope.launch {
             // Check if the file already exists in the gallery, if `skipIfExists` is true.
-            if (skipIfExists && fileExistsInGallery(relativePath, fileName)) {
-                result.success(SaveResultModel(true).toHashMap())
-                return@launch
-            }
-
             val file = File(filePath)
             val extension = file.extension
             val mimeType = getMIMEType(extension)
 
             if (mimeType.isNullOrEmpty()) {
                 result.success(SaveResultModel(false, "Unsupported file type").toHashMap())
+                return@launch
+            }
+
+            val existingUri = if (skipIfExists) findExistingUri(relativePath, fileName, mimeType) else null
+            if (skipIfExists && existingUri != null) {
+                result.success(SaveResultModel(true, savedUri = existingUri.toString()).toHashMap())
                 return@launch
             }
 
@@ -85,7 +89,7 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
 
             // Scan and make the saved file visible in the gallery.
             scanUri(context, uri, mimeType)
-            result.success(SaveResultModel(isSuccess, if (!isSuccess) "Couldn't save the file" else null).toHashMap())
+            result.success(SaveResultModel(isSuccess, if (!isSuccess) "Couldn't save the file" else null, savedUri = if (isSuccess) uri.toString() else null).toHashMap())
         }
     }
 
@@ -98,6 +102,7 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
             var successCount = 0
             var failureCount = 0
             val errors = mutableListOf<String>()
+            val savedUris = mutableListOf<String>()
 
             for (fileData in files) {
                 val filePath = fileData["filePath"] ?: continue
@@ -105,12 +110,6 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
                 val relativePath = fileData["relativePath"] ?: "Download"
 
                 try {
-                    // Check if the file already exists in the gallery, if `skipIfExists` is true.
-                    if (skipIfExists && fileExistsInGallery(relativePath, fileName)) {
-                        successCount++
-                        continue
-                    }
-
                     val file = File(filePath)
                     val extension = file.extension
                     val mimeType = getMIMEType(extension)
@@ -118,6 +117,14 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
                     if (mimeType.isNullOrEmpty()) {
                         failureCount++
                         errors.add("$fileName: Unsupported file type")
+                        continue
+                    }
+
+                    // Check if the file already exists in the gallery, if `skipIfExists` is true.
+                    val existingUri = if (skipIfExists) findExistingUri(relativePath, fileName, mimeType) else null
+                    if (skipIfExists && existingUri != null) {
+                        savedUris.add(existingUri.toString())
+                        successCount++
                         continue
                     }
 
@@ -133,6 +140,7 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
                     if (isSuccess) {
                         // Scan and make the saved file visible in the gallery.
                         scanUri(context, uri, mimeType)
+                        savedUris.add(uri.toString())
                         successCount++
                     } else {
                         failureCount++
@@ -145,10 +153,10 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
             }
 
             val finalResult = if (failureCount == 0) {
-                SaveResultModel(true, null).toHashMap()
+                SaveResultModel(true, null, savedUris = savedUris).toHashMap()
             } else {
                 val errorMessage = "Saved $successCount files, failed $failureCount files. Errors: ${errors.joinToString("; ")}"
-                SaveResultModel(successCount > 0, errorMessage).toHashMap()
+                SaveResultModel(successCount > 0, errorMessage, savedUris = savedUris).toHashMap()
             }
 
             result.success(finalResult)
@@ -242,26 +250,36 @@ class SaverDelegateAndroidT(context: Context) : SaverDelegate(context) {
         }
     }
 
-    // Checks if a file with the given name already exists in the specified relative path.
+    // Finds a file with the given name in the specified relative path.
     @SuppressLint("InlinedApi")
-    private fun fileExistsInGallery(relativePath: String, fileName: String): Boolean {
-        val projection = arrayOf(MediaStore.Images.Media._ID)
+    private fun findExistingUri(relativePath: String, fileName: String, mimeType: String?): Uri? {
+        val contentUri = when {
+            mimeType?.startsWith("video") == true -> MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            mimeType?.startsWith("audio") == true -> MediaStore.Audio.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            else -> MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+        }
+        val projection = arrayOf(MediaStore.MediaColumns._ID)
         val selection = "${MediaStore.Images.Media.RELATIVE_PATH} LIKE ? AND ${MediaStore.Images.Media.DISPLAY_NAME} = ?"
         val selectionArgs = arrayOf("%$relativePath%", fileName)
         val sortOrder = "${MediaStore.Images.Media.DISPLAY_NAME} ASC"
 
         return try {
             context.contentResolver.query(
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                contentUri,
                 projection,
                 selection,
                 selectionArgs,
                 sortOrder
             )?.use { cursor ->
-                cursor.count > 0
-            } ?: false
+                if (cursor.moveToFirst()) {
+                    val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))
+                    ContentUris.withAppendedId(contentUri, id)
+                } else {
+                    null
+                }
+            }
         } catch (e: Exception) {
-            false
+            null
         }
     }
 

--- a/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaverDelegateDefault.kt
+++ b/android/src/main/kotlin/com/mhz/savegallery/saver_gallery/SaverDelegateDefault.kt
@@ -1,6 +1,7 @@
 package com.mhz.savegallery.saver_gallery
 
 import android.annotation.SuppressLint
+import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
@@ -94,6 +95,7 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
             var successCount = 0
             var failureCount = 0
             val errors = mutableListOf<String>()
+            val savedUris = mutableListOf<String>()
 
             for (fileData in files) {
                 val filePath = fileData["filePath"] ?: continue
@@ -104,6 +106,7 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                 val isSuccess = saveResult["isSuccess"] as? Boolean ?: false
 
                 if (isSuccess) {
+                    (saveResult["savedUri"] as? String)?.let { savedUris.add(it) }
                     successCount++
                 } else {
                     failureCount++
@@ -115,10 +118,10 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
             }
 
             val finalResult = if (failureCount == 0) {
-                SaveResultModel(true, null).toHashMap()
+                SaveResultModel(true, null, savedUris = savedUris).toHashMap()
             } else {
                 val errorMessage = "Saved $successCount files, failed $failureCount files. Errors: ${errors.joinToString("; ")}"
-                SaveResultModel(successCount > 0, errorMessage).toHashMap()
+                SaveResultModel(successCount > 0, errorMessage, savedUris = savedUris).toHashMap()
             }
 
             result.success(finalResult)
@@ -144,8 +147,9 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
         skipIfExists: Boolean,
         relativePath: String
     ): HashMap<String, Any?> {
-        return if (skipIfExists && doesFileExist(relativePath, fileName)) {
-            SaveResultModel(true, null).toHashMap()
+        val existingUri = if (skipIfExists) findExistingUri(relativePath, fileName) else null
+        return if (skipIfExists && existingUri != null) {
+            SaveResultModel(true, null, savedUri = existingUri.toString()).toHashMap()
         } else {
             try {
                 val fileUri = generateFileUri(fileName, relativePath)
@@ -154,7 +158,8 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                     outputStream.flush()
                 }
                 notifyGallery(fileUri)
-                SaveResultModel(fileUri.toString().isNotEmpty(), null).toHashMap()
+                val isSuccess = fileUri.toString().isNotEmpty()
+                SaveResultModel(isSuccess, null, savedUri = if (isSuccess) fileUri.toString() else null).toHashMap()
             } catch (e: Exception) {
                 e.printStackTrace()
                 SaveResultModel(false, "Failed to save image: ${e.message}").toHashMap()
@@ -177,8 +182,9 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
         relativePath: String,
         skipIfExists: Boolean
     ): HashMap<String, Any?> {
-        return if (skipIfExists && doesFileExist(relativePath, fileName)) {
-            SaveResultModel(true, null).toHashMap()
+        val existingUri = if (skipIfExists) findExistingUri(relativePath, fileName) else null
+        return if (skipIfExists && existingUri != null) {
+            SaveResultModel(true, null, savedUri = existingUri.toString()).toHashMap()
         } else {
             try {
                 val fileUri = generateFileUri(fileName, relativePath)
@@ -193,7 +199,8 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                     }
                 }
                 notifyGallery(fileUri)
-                SaveResultModel(fileUri.toString().isNotEmpty(), null).toHashMap()
+                val isSuccess = fileUri.toString().isNotEmpty()
+                SaveResultModel(isSuccess, null, savedUri = if (isSuccess) fileUri.toString() else null).toHashMap()
             } catch (e: Exception) {
                 e.printStackTrace()
                 SaveResultModel(false, "Failed to save file: ${e.message}").toHashMap()
@@ -243,18 +250,16 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
         }
     }
 
-    /**
-     * Checks if a file with the given name already exists in the specified relative path.
-     *
-     * @param relativePath The relative path in the gallery.
-     * @param fileName The name of the file to check.
-     * @return True if the file exists, false otherwise.
-     */
     @SuppressLint("InlinedApi")
-    private fun doesFileExist(relativePath: String, fileName: String): Boolean {
+    private fun findExistingUri(relativePath: String, fileName: String): Uri? {
+        val mimeType = getMIMEType(fileName.substringAfterLast('.', ""))
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            val contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-            val projection = arrayOf(MediaStore.Images.Media._ID)
+            val contentUri = when {
+                mimeType?.startsWith("video") == true -> MediaStore.Video.Media.EXTERNAL_CONTENT_URI
+                mimeType?.startsWith("audio") == true -> MediaStore.Audio.Media.EXTERNAL_CONTENT_URI
+                else -> MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+            }
+            val projection = arrayOf(MediaStore.MediaColumns._ID)
             val selection = "${MediaStore.Images.Media.RELATIVE_PATH} LIKE ? AND ${MediaStore.Images.Media.DISPLAY_NAME} = ?"
             val selectionArgs = arrayOf("%$relativePath%", fileName)
             val sortOrder = "${MediaStore.Images.Media.DISPLAY_NAME} ASC"
@@ -267,20 +272,25 @@ class SaverDelegateDefault(context: Context) : SaverDelegate(context) {
                     selectionArgs,
                     sortOrder
                 )?.use { cursor ->
-                    cursor.count > 0
-                } ?: false
+                    if (cursor.moveToFirst()) {
+                        val id = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))
+                        ContentUris.withAppendedId(contentUri, id)
+                    } else {
+                        null
+                    }
+                }
             } catch (e: Exception) {
                 e.printStackTrace()
-                false
+                null
             }
         } else {
             return try {
-                val mimeType = getMIMEType(fileName.substringAfterLast('.', ""))
                 val targetDirectory = resolveLegacyTargetDirectory(relativePath, mimeType)
-                File(targetDirectory, fileName).exists()
+                val existingFile = File(targetDirectory, fileName)
+                if (existingFile.exists()) Uri.fromFile(existingFile) else null
             } catch (e: Exception) {
                 e.printStackTrace()
-                false
+                null
             }
         }
     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -55,7 +55,7 @@ class _MyHomePageState extends State<MyHomePage> {
             _buildButton("Save Local Image", _saveScreen),
             _buildButton("Save Network Image", _getHttp),
             _buildButton("Save Network Video", _saveVideo),
-            _buildButton("Save Gif to Gallery", _saveGif),
+            _buildButton("Save Gif to Album", _saveGif),
             _buildButton("Save Two Gifs", _saveTwoGifs),
           ],
         ),
@@ -119,7 +119,7 @@ class _MyHomePageState extends State<MyHomePage> {
         Uint8List.fromList(response.data),
         quality: 60,
         fileName: picturesPath,
-        androidRelativePath: "Pictures/NetworkImages",
+        albumPath: "NetworkImages",
         skipIfExists: true,
       );
       _showMessage(result.toString());
@@ -128,18 +128,17 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  /// Downloads a GIF from the network and saves it to the gallery.
+  /// Downloads a GIF from the network and saves it to a named album.
   Future<void> _saveGif() async {
     try {
       final response = await Dio().get(
         "https://test-1300597023.cos.ap-singapore.myqcloud.com/hyj-doc-flutter-demo-run%20%281%29.gif",
         options: Options(responseType: ResponseType.bytes),
       );
-      String gifPath = "test_image.gif";
       final result = await SaverGallery.saveImage(
         Uint8List.fromList(response.data),
-        fileName: gifPath,
-        androidRelativePath: "Pictures/appName/images",
+        fileName: "album_image.gif",
+        albumPath: "appName/images",
         skipIfExists: false,
       );
       _showMessage(result.toString());
@@ -157,16 +156,8 @@ class _MyHomePageState extends State<MyHomePage> {
       final bytes = Uint8List.fromList(response.data);
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final results = await Future.wait([
-        SaverGallery.saveImage(
-          bytes,
-          fileName: "parallel_${timestamp}_1.gif",
-          skipIfExists: false,
-        ),
-        SaverGallery.saveImage(
-          bytes,
-          fileName: "parallel_${timestamp}_2.gif",
-          skipIfExists: false,
-        ),
+        SaverGallery.saveImage(bytes, fileName: "parallel_${timestamp}_1.gif", skipIfExists: false),
+        SaverGallery.saveImage(bytes, fileName: "parallel_${timestamp}_2.gif", skipIfExists: false),
       ]);
 
       _showMessage(results.toString());
@@ -194,7 +185,7 @@ class _MyHomePageState extends State<MyHomePage> {
       final result = await SaverGallery.saveFile(
         filePath: savePath,
         fileName: 'downloaded_video.mp4',
-        androidRelativePath: "Movies",
+        albumPath: "appName/videos",
         skipIfExists: true,
       );
       _showMessage(result.toString());

--- a/ios/saver_gallery/Sources/saver_gallery/SaverGalleryPlugin.swift
+++ b/ios/saver_gallery/Sources/saver_gallery/SaverGalleryPlugin.swift
@@ -2,8 +2,15 @@ import Flutter
 import UIKit
 import Photos
 
+enum AlbumPathContainer {
+    case root
+    case existing(PHCollectionList)
+    case created(PHCollectionListChangeRequest)
+}
+
 public class SaverGalleryPlugin: NSObject, FlutterPlugin {
   let errorMessage = "Failed to save, please check whether the permission is enabled"
+  private let photoChangesQueue = DispatchQueue(label: "com.fluttercandies.saver_gallery.photo_changes")
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "com.fluttercandies/saver_gallery", binaryMessenger: registrar.messenger())
@@ -22,11 +29,16 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
             saveResult(isSuccess: false, error: "Invalid arguments", result: result)
             return
         }
+        let albumPathResult = normalizedAlbumPath(arguments["albumPath"] as? String)
+        if let error = albumPathResult.error {
+            saveResult(isSuccess: false, error: error, result: result)
+            return
+        }
         if (isImageFile(fileName: path)) {
-            saveImageAtFileUrl(path, result: result)
+            saveImageAtFileUrl(path, albumPath: albumPathResult.value, result: result)
         } else {
             if (UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(path)) {
-                saveVideo(path, result: result)
+                saveVideo(path, albumPath: albumPathResult.value, result: result)
             } else {
                 saveResult(isSuccess: false, error: "Unsupported file type", result: result)
             }
@@ -52,6 +64,11 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
             saveResult(isSuccess: false, error: "Invalid arguments", result: result)
             return
         }
+        let albumPathResult = normalizedAlbumPath(arguments["albumPath"] as? String)
+        if let error = albumPathResult.error {
+            saveResult(isSuccess: false, error: error, result: result)
+            return
+        }
 
         let extFromArgs = (arguments["extension"] as? String)?.lowercased()
         let extFromFileName = URL(fileURLWithPath: fileName).pathExtension.lowercased()
@@ -67,14 +84,16 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }
 
         var imageIds: [String] = []
-        PHPhotoLibrary.shared().performChanges({
+        performPhotoChanges({
             let req = PHAssetCreationRequest.forAsset()
             let options = PHAssetResourceCreationOptions()
             options.originalFilename = fileName
             req.addResource(with: .photo, data: dataToSave, options: options)
-            if let imageId = req.placeholderForCreatedAsset?.localIdentifier {
+            let placeholder = req.placeholderForCreatedAsset
+            if let imageId = placeholder?.localIdentifier {
                 imageIds.append(imageId)
             }
+            self.addAsset(placeholder, toAlbumPath: albumPathResult.value)
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && imageIds.count > 0) {
@@ -114,10 +133,20 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                 continue
             }
             
+            let albumPathResult = normalizedAlbumPath(fileData["albumPath"])
+            if let error = albumPathResult.error {
+                processedCount += 1
+                failureCount += 1
+                errors.append("\(fileName): \(error)")
+                finishIfNeeded()
+                continue
+            }
+
             if isImageFile(fileName: filePath) {
                 // Save image
-                PHPhotoLibrary.shared().performChanges({
-                    PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: URL(fileURLWithPath: filePath))
+                performPhotoChanges({
+                    let req = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: URL(fileURLWithPath: filePath))
+                    self.addAsset(req?.placeholderForCreatedAsset, toAlbumPath: albumPathResult.value)
                 }, completionHandler: { (success, error) in
                     DispatchQueue.main.async {
                         processedCount += 1
@@ -133,8 +162,9 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                 })
             } else if UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(filePath) {
                 // Save video
-                PHPhotoLibrary.shared().performChanges({
-                    PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: URL(fileURLWithPath: filePath))
+                performPhotoChanges({
+                    let req = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: URL(fileURLWithPath: filePath))
+                    self.addAsset(req?.placeholderForCreatedAsset, toAlbumPath: albumPathResult.value)
                 }, completionHandler: { (success, error) in
                     DispatchQueue.main.async {
                         processedCount += 1
@@ -157,14 +187,16 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }
     }
 
-    func saveVideo(_ path: String, result: @escaping FlutterResult) {
+    func saveVideo(_ path: String, albumPath: String?, result: @escaping FlutterResult) {
         var videoIds: [String] = []
 
-        PHPhotoLibrary.shared().performChanges( {
+        performPhotoChanges( {
             let req = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: URL.init(fileURLWithPath: path))
-            if let videoId = req?.placeholderForCreatedAsset?.localIdentifier {
+            let placeholder = req?.placeholderForCreatedAsset
+            if let videoId = placeholder?.localIdentifier {
                 videoIds.append(videoId)
             }
+            self.addAsset(placeholder, toAlbumPath: albumPath)
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && videoIds.count > 0) {
@@ -176,15 +208,17 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         })
     }
 
-    func saveImageAtFileUrl(_ url: String, result: @escaping FlutterResult) {
+    func saveImageAtFileUrl(_ url: String, albumPath: String?, result: @escaping FlutterResult) {
   
         var imageIds: [String] = []
 
-        PHPhotoLibrary.shared().performChanges( {
+        performPhotoChanges( {
             let req = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: URL(string: url)!)
-            if let imageId = req?.placeholderForCreatedAsset?.localIdentifier {
+            let placeholder = req?.placeholderForCreatedAsset
+            if let imageId = placeholder?.localIdentifier {
                 imageIds.append(imageId)
             }
+            self.addAsset(placeholder, toAlbumPath: albumPath)
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && imageIds.count > 0) {
@@ -194,6 +228,148 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                 }
             }
         })
+    }
+
+    func performPhotoChanges(_ changes: @escaping () -> Void, completionHandler: @escaping (Bool, Error?) -> Void) {
+        photoChangesQueue.async {
+            let semaphore = DispatchSemaphore(value: 0)
+            PHPhotoLibrary.shared().performChanges(changes, completionHandler: { success, error in
+                completionHandler(success, error)
+                semaphore.signal()
+            })
+            semaphore.wait()
+        }
+    }
+
+    func normalizedAlbumPath(_ albumPath: String?) -> (value: String?, error: String?) {
+        guard let value = albumPath?.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "\\", with: "/"), !value.isEmpty else {
+            return (nil, nil)
+        }
+
+        let normalizedPath = value.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let segments = normalizedPath.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        let isWindowsAbsolutePath = normalizedPath.range(of: #"^[A-Za-z]:"#, options: .regularExpression) != nil
+        let isUnsafe = value.hasPrefix("/")
+            || normalizedPath.isEmpty
+            || isWindowsAbsolutePath
+            || segments.contains { segment in segment.isEmpty || segment == "." || segment == ".." }
+        if isUnsafe {
+            return (nil, "albumPath must be a relative album hierarchy path")
+        }
+
+        return (normalizedPath, nil)
+    }
+
+    func addAsset(_ placeholder: PHObjectPlaceholder?, toAlbumPath albumPath: String?) {
+        guard let placeholder = placeholder, let albumPath = albumPath else {
+            return
+        }
+
+        var pathSegments = albumPath.split(separator: "/").map(String.init)
+        guard let albumName = pathSegments.popLast() else {
+            return
+        }
+
+        var container = AlbumPathContainer.root
+        for folderName in pathSegments {
+            container = resolveFolder(named: folderName, in: container)
+        }
+
+        addAsset(placeholder, toAlbumNamed: albumName, in: container)
+    }
+
+    func resolveFolder(named folderName: String, in container: AlbumPathContainer) -> AlbumPathContainer {
+        switch container {
+        case .root:
+            if let folder = fetchFolder(named: folderName, in: nil) {
+                return .existing(folder)
+            }
+
+            let request = PHCollectionListChangeRequest.creationRequestForCollectionList(withTitle: folderName)
+            return .created(request)
+        case .existing(let parent):
+            if let folder = fetchFolder(named: folderName, in: parent) {
+                return .existing(folder)
+            }
+
+            let request = PHCollectionListChangeRequest.creationRequestForCollectionList(withTitle: folderName)
+            addCollection(request.placeholderForCreatedCollectionList, to: container)
+            return .created(request)
+        case .created(let parentRequest):
+            let request = PHCollectionListChangeRequest.creationRequestForCollectionList(withTitle: folderName)
+            parentRequest.addChildCollections([request.placeholderForCreatedCollectionList] as NSArray)
+            return .created(request)
+        }
+    }
+
+    func addAsset(_ placeholder: PHObjectPlaceholder, toAlbumNamed albumName: String, in container: AlbumPathContainer) {
+        switch container {
+        case .root:
+            if let album = fetchAlbum(named: albumName, in: nil) {
+                PHAssetCollectionChangeRequest(for: album)?.addAssets([placeholder] as NSArray)
+                return
+            }
+
+            let request = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: albumName)
+            request.addAssets([placeholder] as NSArray)
+        case .existing(let parent):
+            if let album = fetchAlbum(named: albumName, in: parent) {
+                PHAssetCollectionChangeRequest(for: album)?.addAssets([placeholder] as NSArray)
+                return
+            }
+
+            let request = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: albumName)
+            request.addAssets([placeholder] as NSArray)
+            addCollection(request.placeholderForCreatedAssetCollection, to: container)
+        case .created(let parentRequest):
+            let request = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(withTitle: albumName)
+            request.addAssets([placeholder] as NSArray)
+            parentRequest.addChildCollections([request.placeholderForCreatedAssetCollection] as NSArray)
+        }
+    }
+
+    func addCollection(_ placeholder: PHObjectPlaceholder, to container: AlbumPathContainer) {
+        switch container {
+        case .root:
+            return
+        case .existing(let parent):
+            PHCollectionListChangeRequest(for: parent)?.addChildCollections([placeholder] as NSArray)
+        case .created(let parentRequest):
+            parentRequest.addChildCollections([placeholder] as NSArray)
+        }
+    }
+
+    func fetchFolder(named folderName: String, in parent: PHCollectionList?) -> PHCollectionList? {
+        let collections = fetchCollections(named: folderName, in: parent)
+        var matchedFolder: PHCollectionList?
+        collections.enumerateObjects { collection, _, stop in
+            if let folder = collection as? PHCollectionList, folder.localizedTitle == folderName {
+                matchedFolder = folder
+                stop.pointee = true
+            }
+        }
+        return matchedFolder
+    }
+
+    func fetchAlbum(named albumName: String, in parent: PHCollectionList?) -> PHAssetCollection? {
+        let collections = fetchCollections(named: albumName, in: parent)
+        var matchedAlbum: PHAssetCollection?
+        collections.enumerateObjects { collection, _, stop in
+            if let album = collection as? PHAssetCollection, album.localizedTitle == albumName {
+                matchedAlbum = album
+                stop.pointee = true
+            }
+        }
+        return matchedAlbum
+    }
+
+    func fetchCollections(named collectionName: String, in parent: PHCollectionList?) -> PHFetchResult<PHCollection> {
+        let options = PHFetchOptions()
+        options.predicate = NSPredicate(format: "title = %@", collectionName)
+        if let parent = parent {
+            return PHCollection.fetchCollections(in: parent, options: options)
+        }
+        return PHCollectionList.fetchTopLevelUserCollections(with: options)
     }
 
     func saveResult(isSuccess: Bool, error: String? = nil, result: FlutterResult) {

--- a/ios/saver_gallery/Sources/saver_gallery/SaverGalleryPlugin.swift
+++ b/ios/saver_gallery/Sources/saver_gallery/SaverGalleryPlugin.swift
@@ -97,7 +97,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && imageIds.count > 0) {
-                    self.saveResult(isSuccess: true, result: result)
+                    self.saveResult(isSuccess: true, savedUri: self.photoUri(from: imageIds.first), result: result)
                 } else {
                     self.saveResult(isSuccess: false, error: self.errorMessage, result: result)
                 }
@@ -109,6 +109,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         var successCount = 0
         var failureCount = 0
         var errors: [String] = []
+        var savedUris: [String] = []
         let totalFiles = files.count
         var processedCount = 0
 
@@ -119,7 +120,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
 
         func finishIfNeeded() {
             if processedCount == totalFiles {
-                self.saveBatchResult(successCount: successCount, failureCount: failureCount, errors: errors, result: result)
+                self.saveBatchResult(successCount: successCount, failureCount: failureCount, errors: errors, savedUris: savedUris, result: result)
             }
         }
         
@@ -143,14 +144,20 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
             }
 
             if isImageFile(fileName: filePath) {
+                var savedUri: String?
                 // Save image
                 performPhotoChanges({
                     let req = PHAssetChangeRequest.creationRequestForAssetFromImage(atFileURL: URL(fileURLWithPath: filePath))
-                    self.addAsset(req?.placeholderForCreatedAsset, toAlbumPath: albumPathResult.value)
+                    let placeholder = req?.placeholderForCreatedAsset
+                    savedUri = self.photoUri(from: placeholder?.localIdentifier)
+                    self.addAsset(placeholder, toAlbumPath: albumPathResult.value)
                 }, completionHandler: { (success, error) in
                     DispatchQueue.main.async {
                         processedCount += 1
                         if success {
+                            if let savedUri = savedUri {
+                                savedUris.append(savedUri)
+                            }
                             successCount += 1
                         } else {
                             failureCount += 1
@@ -161,14 +168,20 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
                     }
                 })
             } else if UIVideoAtPathIsCompatibleWithSavedPhotosAlbum(filePath) {
+                var savedUri: String?
                 // Save video
                 performPhotoChanges({
                     let req = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: URL(fileURLWithPath: filePath))
-                    self.addAsset(req?.placeholderForCreatedAsset, toAlbumPath: albumPathResult.value)
+                    let placeholder = req?.placeholderForCreatedAsset
+                    savedUri = self.photoUri(from: placeholder?.localIdentifier)
+                    self.addAsset(placeholder, toAlbumPath: albumPathResult.value)
                 }, completionHandler: { (success, error) in
                     DispatchQueue.main.async {
                         processedCount += 1
                         if success {
+                            if let savedUri = savedUri {
+                                savedUris.append(savedUri)
+                            }
                             successCount += 1
                         } else {
                             failureCount += 1
@@ -200,7 +213,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && videoIds.count > 0) {
-                    self.saveResult(isSuccess: true, result: result)
+                    self.saveResult(isSuccess: true, savedUri: self.photoUri(from: videoIds.first), result: result)
                 } else {
                     self.saveResult(isSuccess: false, error: self.errorMessage, result: result)
                 }
@@ -222,7 +235,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         }, completionHandler: { [unowned self] (success, error) in
             DispatchQueue.main.async {
                 if (success && imageIds.count > 0) {
-                    self.saveResult(isSuccess: true, result: result)
+                    self.saveResult(isSuccess: true, savedUri: self.photoUri(from: imageIds.first), result: result)
                 } else {
                     self.saveResult(isSuccess: false, error: self.errorMessage, result: result)
                 }
@@ -372,14 +385,25 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
         return PHCollectionList.fetchTopLevelUserCollections(with: options)
     }
 
-    func saveResult(isSuccess: Bool, error: String? = nil, result: FlutterResult) {
+    func photoUri(from localIdentifier: String?) -> String? {
+        guard let localIdentifier = localIdentifier else {
+            return nil
+        }
+        return "ph://\(localIdentifier)"
+    }
+
+    func saveResult(isSuccess: Bool, error: String? = nil, savedUri: String? = nil, result: FlutterResult) {
         var saveResult = SaveResultModel()
         saveResult.isSuccess = isSuccess
         saveResult.errorMessage = error?.description
+        saveResult.savedUri = savedUri
+        if let savedUri = savedUri {
+            saveResult.savedUris = [savedUri]
+        }
         result(saveResult.toDic())
     }
 
-    func saveBatchResult(successCount: Int, failureCount: Int, errors: [String], result: FlutterResult) {
+    func saveBatchResult(successCount: Int, failureCount: Int, errors: [String], savedUris: [String], result: FlutterResult) {
         var saveResult = SaveResultModel()
         if failureCount == 0 {
             saveResult.isSuccess = true
@@ -389,6 +413,7 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
             let errorMessage = "Saved \(successCount) files, failed \(failureCount) files. Errors: \(errors.joined(separator: "; "))"
             saveResult.errorMessage = errorMessage
         }
+        saveResult.savedUris = savedUris
         result(saveResult.toDic())
     }
 
@@ -411,6 +436,8 @@ public class SaverGalleryPlugin: NSObject, FlutterPlugin {
 public struct SaveResultModel: Encodable {
     var isSuccess: Bool!
     var errorMessage: String?
+    var savedUri: String?
+    var savedUris: [String]?
 
     func toDic() -> [String:Any]? {
         let encoder = JSONEncoder()

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -38,16 +38,21 @@ class SaveFileData {
 class SaveResult {
   final bool isSuccess;
   final String? errorMessage;
+  final String? savedUri;
+  final List<String> savedUris;
 
-  SaveResult(this.isSuccess, this.errorMessage);
+  SaveResult(this.isSuccess, this.errorMessage, {this.savedUri, List<String>? savedUris})
+    : savedUris = savedUris ?? (savedUri == null ? const <String>[] : <String>[savedUri]);
 
   /// Creates a [SaveResult] from a map.
   factory SaveResult.fromMap(Map<String, dynamic> json) {
-    return SaveResult(json['isSuccess'], json['errorMessage']);
+    final savedUri = json['savedUri'] as String?;
+    final savedUris = (json['savedUris'] as List?)?.whereType<String>().toList();
+    return SaveResult(json['isSuccess'], json['errorMessage'], savedUri: savedUri, savedUris: savedUris);
   }
 
   @override
   String toString() {
-    return 'SaveResult{isSuccess: $isSuccess, errorMessage: $errorMessage}';
+    return 'SaveResult{isSuccess: $isSuccess, errorMessage: $errorMessage, savedUri: $savedUri, savedUris: $savedUris}';
   }
 }

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -6,12 +6,12 @@ class SaveImageData {
   final Uint8List bytes;
   final String fileName;
   final String? extension;
-  final String? androidRelativePath;
+  final String? albumPath;
 
   SaveImageData({
     required this.bytes,
     required this.fileName,
-    this.androidRelativePath,
+    this.albumPath,
     this.extension,
   });
 }
@@ -20,23 +20,16 @@ class SaveImageData {
 class SaveFileData {
   final String filePath;
   final String fileName;
-  final String? androidRelativePath;
+  final String? albumPath;
 
-  SaveFileData({
-    required this.filePath,
-    required this.fileName,
-    this.androidRelativePath,
-  });
+  SaveFileData({required this.filePath, required this.fileName, this.albumPath});
 
   /// Creates a [SaveFileData] instance from a [File] object.
-  factory SaveFileData.fromFile(
-    File file, {
-    String? androidRelativePath,
-  }) {
+  factory SaveFileData.fromFile(File file, {String? albumPath}) {
     return SaveFileData(
       filePath: file.path,
       fileName: file.uri.pathSegments.last,
-      androidRelativePath: androidRelativePath,
+      albumPath: albumPath,
     );
   }
 }

--- a/lib/src/saver_gallery.dart
+++ b/lib/src/saver_gallery.dart
@@ -11,9 +11,9 @@ import './model.dart';
 
 /// A utility class for saving images and files to the device's media gallery.
 class SaverGallery {
-  static const MethodChannel _channel =
-      MethodChannel('com.fluttercandies/saver_gallery');
+  static const MethodChannel _channel = MethodChannel('com.fluttercandies/saver_gallery');
   static final Uuid _uuidGenerator = Uuid();
+
   static Future<Directory> get _cacheDirectory async {
     final tempDir = await getTemporaryDirectory();
     final cacheDir = Directory('${tempDir.path}/saver_gallery');
@@ -29,7 +29,7 @@ class SaverGallery {
   /// [quality] specifies the quality of the image (for JPG files).
   /// [extension] is optional; if not provided, it will be inferred from the file name.
   /// [fileName] is the name of the file to save.
-  /// [androidRelativePath] is the folder path for Android devices. Defaults to the appropriate type-based path.
+  /// [albumPath] is the album hierarchy path for Android and iOS.
   /// [skipIfExists] if true, skips saving if the file already exists.
   ///
   /// Returns a [SaveResult] indicating success or failure.
@@ -38,9 +38,14 @@ class SaverGallery {
     int quality = 100,
     String? extension,
     required String fileName,
-    String? androidRelativePath,
+    String? albumPath,
     required bool skipIfExists,
   }) async {
+    final normalizedAlbumPath = _normalizeAlbumPath(albumPath);
+    if (normalizedAlbumPath.errorMessage != null) {
+      return SaveResult(false, normalizedAlbumPath.errorMessage);
+    }
+
     // Determine the MIME type and file extension.
     String? mimeType = lookupMimeType(fileName, headerBytes: imageBytes);
     extension ??= _extractFileExtension(mimeType, fileName);
@@ -52,18 +57,18 @@ class SaverGallery {
 
     try {
       // Call the native method to save the image to the gallery.
-      final result = await _channel.invokeMapMethod<String, dynamic>(
-        'saveImageToGallery',
-        <String, dynamic>{
-          'image': imageBytes,
-          'quality': quality,
-          'fileName': fileName,
-          'extension': extension,
-          'relativePath':
-              androidRelativePath ?? _getDefaultRelativePathForType(mimeType),
-          'skipIfExists': skipIfExists,
-        },
-      );
+      final result = await _channel.invokeMapMethod<String, dynamic>('saveImageToGallery', <String, dynamic>{
+        'image': imageBytes,
+        'quality': quality,
+        'fileName': fileName,
+        'extension': extension,
+        'relativePath': _resolveRelativePath(
+          albumPath: normalizedAlbumPath.value,
+          mimeType: mimeType,
+        ),
+        'albumPath': normalizedAlbumPath.value,
+        'skipIfExists': skipIfExists,
+      });
 
       return SaveResult.fromMap(result!);
     } catch (e) {
@@ -76,31 +81,36 @@ class SaverGallery {
   ///
   /// [filePath] is the path of the file to be saved.
   /// [fileName] is the name of the file to save in the gallery.
-  /// [androidRelativePath] is the folder path for Android devices. Defaults to the appropriate type-based path.
+  /// [albumPath] is the album hierarchy path for Android and iOS.
   /// [skipIfExists] if true, skips saving if the file already exists.
   ///
   /// Returns a [SaveResult] indicating success or failure.
   static Future<SaveResult> saveFile({
     required String filePath,
     required String fileName,
-    String? androidRelativePath,
+    String? albumPath,
     required bool skipIfExists,
   }) async {
+    final normalizedAlbumPath = _normalizeAlbumPath(albumPath);
+    if (normalizedAlbumPath.errorMessage != null) {
+      return SaveResult(false, normalizedAlbumPath.errorMessage);
+    }
+
     // Determine the MIME type based on the file path.
     String? mimeType = lookupMimeType(filePath);
 
     try {
       // Call the native method to save the file to the gallery.
-      final result = await _channel.invokeMapMethod<String, dynamic>(
-        'saveFileToGallery',
-        <String, dynamic>{
-          'filePath': filePath,
-          'fileName': fileName,
-          'relativePath':
-              androidRelativePath ?? _getDefaultRelativePathForType(mimeType),
-          'skipIfExists': skipIfExists,
-        },
-      );
+      final result = await _channel.invokeMapMethod<String, dynamic>('saveFileToGallery', <String, dynamic>{
+        'filePath': filePath,
+        'fileName': fileName,
+        'relativePath': _resolveRelativePath(
+          albumPath: normalizedAlbumPath.value,
+          mimeType: mimeType,
+        ),
+        'albumPath': normalizedAlbumPath.value,
+        'skipIfExists': skipIfExists,
+      });
 
       return SaveResult.fromMap(result!);
     } catch (e) {
@@ -131,10 +141,8 @@ class SaverGallery {
 
     try {
       for (var imageData in images) {
-        String? mimeType =
-            lookupMimeType(imageData.fileName, headerBytes: imageData.bytes);
-        String extension = imageData.extension ??
-            _extractFileExtension(mimeType, imageData.fileName);
+        String? mimeType = lookupMimeType(imageData.fileName, headerBytes: imageData.bytes);
+        String extension = imageData.extension ?? _extractFileExtension(mimeType, imageData.fileName);
 
         String fileName = imageData.fileName;
         if (!fileName.contains('.')) {
@@ -145,19 +153,17 @@ class SaverGallery {
         final tempFile = await _createTempFile(extension, imageData.bytes);
         tempFiles.add(tempFile);
 
-        // Use per-image androidRelativePath from ImageData
-        fileDataList.add(SaveFileData(
-          filePath: tempFile.path,
-          fileName: fileName,
-          androidRelativePath: imageData.androidRelativePath,
-        ));
+        fileDataList.add(
+          SaveFileData(
+            filePath: tempFile.path,
+            fileName: fileName,
+            albumPath: imageData.albumPath,
+          ),
+        );
       }
 
       // Save all files in batch (saveFiles will handle individual paths)
-      final result = await saveFiles(
-        fileDataList,
-        skipIfExists: skipIfExists,
-      );
+      final result = await saveFiles(fileDataList, skipIfExists: skipIfExists);
 
       return result;
     } finally {
@@ -180,37 +186,40 @@ class SaverGallery {
   /// [skipIfExists] if true, skips saving if a file already exists.
   ///
   /// Returns a [SaveResult] indicating success or failure for the batch operation.
-  static Future<SaveResult> saveFiles(
-    List<SaveFileData> files, {
-    required bool skipIfExists,
-  }) async {
+  static Future<SaveResult> saveFiles(List<SaveFileData> files, {required bool skipIfExists}) async {
     if (files.isEmpty) {
       return SaveResult(false, 'File list is empty');
     }
 
-    // Convert FileData list to maps for native method call
-    final List<Map<String, dynamic>> _files = files.map((fileData) {
-      String? mimeType = lookupMimeType(fileData.filePath);
-
-      // Use FileData.androidRelativePath, or default based on MIME type
-      String relativePath = fileData.androidRelativePath ??
-          _getDefaultRelativePathForType(mimeType);
-
-      return {
-        'filePath': fileData.filePath,
-        'fileName': fileData.fileName,
-        'relativePath': relativePath,
-      };
-    }).toList();
-
     try {
-      final result = await _channel.invokeMapMethod<String, dynamic>(
-        'saveFilesToGallery',
-        <String, dynamic>{
-          'files': _files,
-          'skipIfExists': skipIfExists,
-        },
-      );
+      // Convert FileData list to maps for native method call
+      final List<Map<String, dynamic>> _files = files.map((fileData) {
+        String? mimeType = lookupMimeType(fileData.filePath);
+        final normalizedAlbumPath = _normalizeAlbumPath(fileData.albumPath);
+        if (normalizedAlbumPath.errorMessage != null) {
+          throw ArgumentError(normalizedAlbumPath.errorMessage);
+        }
+
+        String relativePath = _resolveRelativePath(
+          albumPath: normalizedAlbumPath.value,
+          mimeType: mimeType,
+        );
+
+        final file = <String, dynamic>{
+          'filePath': fileData.filePath,
+          'fileName': fileData.fileName,
+          'relativePath': relativePath,
+        };
+        if (normalizedAlbumPath.value != null) {
+          file['albumPath'] = normalizedAlbumPath.value;
+        }
+        return file;
+      }).toList();
+
+      final result = await _channel.invokeMapMethod<String, dynamic>('saveFilesToGallery', <String, dynamic>{
+        'files': _files,
+        'skipIfExists': skipIfExists,
+      });
 
       return SaveResult.fromMap(result!);
     } catch (e) {
@@ -223,8 +232,7 @@ class SaverGallery {
   /// [mimeType] is the MIME type of the file.
   /// Returns the default relative path as a string based on the type of file.
   static String _getDefaultRelativePathForType(String? mimeType) {
-    if (mimeType == null)
-      return "Download"; // Default path if MIME type is unknown.
+    if (mimeType == null) return "Download"; // Default path if MIME type is unknown.
 
     if (mimeType.startsWith("image/")) {
       return "Pictures"; // Corresponds to Environment.DIRECTORY_PICTURES
@@ -235,6 +243,59 @@ class SaverGallery {
     } else {
       return "Documents"; // Corresponds to Environment.DIRECTORY_DOCUMENTS for other types.
     }
+  }
+
+  static String _resolveRelativePath({
+    required String? albumPath,
+    required String? mimeType,
+  }) {
+    final defaultPath = _getDefaultRelativePathForType(mimeType);
+    if (albumPath == null) {
+      return defaultPath;
+    }
+
+    if (_hasKnownPublicDirectoryPrefix(albumPath)) {
+      return albumPath;
+    }
+    return '$defaultPath/$albumPath';
+  }
+
+  static bool _hasKnownPublicDirectoryPrefix(String albumPath) {
+    const publicDirectoryPrefixes = <String>{
+      'Pictures',
+      'Movies',
+      'Music',
+      'Documents',
+      'Download',
+      'Downloads',
+      'DCIM',
+    };
+
+    final firstSegment = albumPath.split('/').first;
+    return publicDirectoryPrefixes.contains(firstSegment);
+  }
+
+  static _AlbumPathValidation _normalizeAlbumPath(String? albumPath) {
+    final path = albumPath?.trim().replaceAll('\\', '/');
+    if (path == null || path.isEmpty) {
+      return _AlbumPathValidation(null, null);
+    }
+
+    final isAbsolutePath = path.startsWith('/');
+    final normalizedPath = path.replaceAll(RegExp(r'^/+|/+$'), '');
+    final isWindowsAbsolutePath = RegExp(r'^[a-zA-Z]:').hasMatch(normalizedPath);
+    final segments = normalizedPath.split('/');
+    final isUnsafe =
+        normalizedPath.isEmpty ||
+        isAbsolutePath ||
+        isWindowsAbsolutePath ||
+        segments.any((segment) => segment.isEmpty || segment == '.' || segment == '..');
+
+    if (isUnsafe) {
+      return _AlbumPathValidation(null, 'albumPath must be a relative album hierarchy path');
+    }
+
+    return _AlbumPathValidation(normalizedPath, null);
   }
 
   /// Extracts the file extension from the MIME type or falls back to the file name.
@@ -253,8 +314,7 @@ class SaverGallery {
   /// [extension] is the file extension to use.
   /// [bytes] is the data to be written to the temporary file.
   static Future<File> _createTempFile(String extension, Uint8List bytes) async {
-    final tempPath =
-        '${(await _cacheDirectory).path}/${_uuidGenerator.v4()}.$extension';
+    final tempPath = '${(await _cacheDirectory).path}/${_uuidGenerator.v4()}.$extension';
     final tempFile = File(tempPath)..createSync(recursive: true);
     await tempFile.writeAsBytes(bytes);
     return tempFile;
@@ -279,4 +339,11 @@ class SaverGallery {
       return false;
     }
   }
+}
+
+class _AlbumPathValidation {
+  final String? value;
+  final String? errorMessage;
+
+  const _AlbumPathValidation(this.value, this.errorMessage);
 }

--- a/ohos/src/main/ets/components/plugin/SaverGalleryPlugin.ets
+++ b/ohos/src/main/ets/components/plugin/SaverGalleryPlugin.ets
@@ -86,7 +86,7 @@ export default class SaverGalleryPlugin implements FlutterPlugin, MethodCallHand
       await fs.copyFile(srcFile.fd, desFile.fd);
       fs.closeSync(srcFile);
       fs.closeSync(desFile);
-      return SaveResultModel.toHashMap(true, null);
+      return SaveResultModel.toHashMap(true, null, desFileUris[0], [desFileUris[0]]);
     } catch (err) {
       return SaveResultModel.toHashMap(false, `save failed, errCode is ${err.code}, errMsg is ${err.message}`);
     }
@@ -188,7 +188,7 @@ export default class SaverGalleryPlugin implements FlutterPlugin, MethodCallHand
         fs.closeSync(desFile);
       }
 
-      return SaveResultModel.toHashMap(true, null);
+      return SaveResultModel.toHashMap(true, null, null, desFileUris);
     } catch (err) {
       return SaveResultModel.toHashMap(false, `batch save failed, errCode is ${err.code}, errMsg is ${err.message}`);
     }
@@ -234,10 +234,17 @@ export default class SaverGalleryPlugin implements FlutterPlugin, MethodCallHand
 }
 
 class SaveResultModel {
-  static toHashMap(isSuccess: boolean, errorMessage: string | null): HashMap<String, ESObject> {
+  static toHashMap(
+    isSuccess: boolean,
+    errorMessage: string | null,
+    savedUri: string | null = null,
+    savedUris: Array<string> = []
+  ): HashMap<String, ESObject> {
     let hashMap: HashMap<String, ESObject> = new HashMap();
     hashMap.set("isSuccess", isSuccess);
     hashMap.set("errorMessage", errorMessage);
+    hashMap.set("savedUri", savedUri);
+    hashMap.set("savedUris", savedUris.length > 0 ? savedUris : (savedUri ? [savedUri] : []));
     if (errorMessage) {
       isSuccess ? Log.d(TAG, errorMessage) : Log.e(TAG, errorMessage);
     }

--- a/test/saver_gallery_test.dart
+++ b/test/saver_gallery_test.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:saver_gallery/saver_gallery.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel("com.fluttercandies/saver_gallery");
+
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return <String, dynamic>{"isSuccess": true, "errorMessage": null};
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test("saveImage maps albumPath to Pictures relativePath", () async {
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      albumPath: "MyAlbum",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, true);
+    expect(calls, hasLength(1));
+    expect(calls.single.method, "saveImageToGallery");
+
+    final arguments = calls.single.arguments as Map<Object?, Object?>;
+    expect(arguments["relativePath"], "Pictures/MyAlbum");
+    expect(arguments["albumPath"], "MyAlbum");
+  });
+
+  test("saveImage combines neutral albumPath with default image directory", () async {
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      albumPath: "appName/images",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, true);
+    expect(calls, hasLength(1));
+
+    final arguments = calls.single.arguments as Map<Object?, Object?>;
+    expect(arguments["relativePath"], "Pictures/appName/images");
+    expect(arguments["albumPath"], "appName/images");
+  });
+
+  test("saveImage keeps albumPath with known public directory prefix", () async {
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      albumPath: "Pictures/appName/images",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, true);
+    expect(calls, hasLength(1));
+
+    final arguments = calls.single.arguments as Map<Object?, Object?>;
+    expect(arguments["relativePath"], "Pictures/appName/images");
+    expect(arguments["albumPath"], "Pictures/appName/images");
+  });
+
+  test("saveFile maps video albumPath to Movies relativePath", () async {
+    final result = await SaverGallery.saveFile(
+      filePath: "/tmp/sample.mp4",
+      fileName: "sample.mp4",
+      albumPath: "appName/videos",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, true);
+    expect(calls, hasLength(1));
+
+    final arguments = calls.single.arguments as Map<Object?, Object?>;
+    expect(arguments["relativePath"], "Movies/appName/videos");
+    expect(arguments["albumPath"], "appName/videos");
+  });
+
+  test("saveFiles preserves per-file albumPath and relativePath", () async {
+    final result = await SaverGallery.saveFiles(<SaveFileData>[
+      SaveFileData(
+        filePath: "/tmp/sample.png",
+        fileName: "sample.png",
+        albumPath: "appName/images",
+      ),
+      SaveFileData(
+        filePath: "/tmp/sample.mp4",
+        fileName: "sample.mp4",
+        albumPath: "appName/videos",
+      ),
+    ], skipIfExists: false);
+
+    expect(result.isSuccess, true);
+    expect(calls, hasLength(1));
+
+    final arguments = calls.single.arguments as Map<Object?, Object?>;
+    final files = arguments["files"] as List<Object?>;
+
+    expect(files[0], containsPair("relativePath", "Pictures/appName/images"));
+    expect(files[0], containsPair("albumPath", "appName/images"));
+    expect(files[1], containsPair("relativePath", "Movies/appName/videos"));
+    expect(files[1], containsPair("albumPath", "appName/videos"));
+  });
+
+  test("invalid albumPath returns failure without calling native channel", () async {
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      albumPath: "bad/../name",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, false);
+    expect(result.errorMessage, contains("albumPath"));
+    expect(calls, isEmpty);
+  });
+
+  test("absolute albumPath returns failure without calling native channel", () async {
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      albumPath: "/Pictures",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, false);
+    expect(result.errorMessage, contains("albumPath"));
+    expect(calls, isEmpty);
+  });
+
+  test("windows absolute albumPath returns failure without calling native channel", () async {
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      albumPath: "C:/Pictures",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, false);
+    expect(result.errorMessage, contains("albumPath"));
+    expect(calls, isEmpty);
+  });
+}

--- a/test/saver_gallery_test.dart
+++ b/test/saver_gallery_test.dart
@@ -21,6 +21,86 @@ void main() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
   });
 
+  test("SaveResult parses savedUri and mirrors it into savedUris", () {
+    final result = SaveResult.fromMap(<String, dynamic>{
+      "isSuccess": true,
+      "errorMessage": null,
+      "savedUri": "content://media/external/images/media/1",
+    });
+
+    expect(result.isSuccess, true);
+    expect(result.errorMessage, null);
+    expect(result.savedUri, "content://media/external/images/media/1");
+    expect(result.savedUris, <String>["content://media/external/images/media/1"]);
+  });
+
+  test("SaveResult parses savedUris", () {
+    final result = SaveResult.fromMap(<String, dynamic>{
+      "isSuccess": true,
+      "errorMessage": null,
+      "savedUris": <String>["content://one", "content://two"],
+    });
+
+    expect(result.isSuccess, true);
+    expect(result.errorMessage, null);
+    expect(result.savedUri, null);
+    expect(result.savedUris, <String>["content://one", "content://two"]);
+  });
+
+  test("SaveResult uses empty uri fields when save failed", () {
+    final result = SaveResult.fromMap(<String, dynamic>{
+      "isSuccess": false,
+      "errorMessage": "failed",
+    });
+
+    expect(result.isSuccess, false);
+    expect(result.errorMessage, "failed");
+    expect(result.savedUri, null);
+    expect(result.savedUris, isEmpty);
+  });
+
+  test("saveImage exposes native savedUri", () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return <String, dynamic>{
+        "isSuccess": true,
+        "errorMessage": null,
+        "savedUri": "content://media/external/images/media/1",
+      };
+    });
+
+    final result = await SaverGallery.saveImage(
+      Uint8List.fromList(<int>[1, 2, 3]),
+      extension: "png",
+      fileName: "sample.png",
+      skipIfExists: false,
+    );
+
+    expect(result.isSuccess, true);
+    expect(result.savedUri, "content://media/external/images/media/1");
+    expect(result.savedUris, <String>["content://media/external/images/media/1"]);
+  });
+
+  test("saveFiles exposes native savedUris", () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return <String, dynamic>{
+        "isSuccess": true,
+        "errorMessage": null,
+        "savedUris": <String>["content://one", "content://two"],
+      };
+    });
+
+    final result = await SaverGallery.saveFiles(<SaveFileData>[
+      SaveFileData(filePath: "/tmp/sample.png", fileName: "sample.png"),
+      SaveFileData(filePath: "/tmp/sample.mp4", fileName: "sample.mp4"),
+    ], skipIfExists: false);
+
+    expect(result.isSuccess, true);
+    expect(result.savedUri, null);
+    expect(result.savedUris, <String>["content://one", "content://two"]);
+  });
+
   test("saveImage maps albumPath to Pictures relativePath", () async {
     final result = await SaverGallery.saveImage(
       Uint8List.fromList(<int>[1, 2, 3]),


### PR DESCRIPTION
## Summary

Implement #23 by adding full cross-platform album destination support and returning saved media locations.

This PR replaces the Android-only `androidRelativePath` API with `albumPath`, then adds saved URI results so callers can know where the media was saved.

`albumPath` represents an album hierarchy:

- Android image: `albumPath: "appName/images"` -> `Pictures/appName/images`
- Android video: `albumPath: "appName/videos"` -> `Movies/appName/videos`
- iOS: `albumPath: "appName/images"` -> Photos folder `appName` containing album `images`

`SaveResult` now also exposes platform-specific saved media identifiers:

- Android 10+: `content://...`
- Android 9 and below: `file://...`
- iOS: `ph://...`
- OHOS: media library URI

## Changes

- Replace `androidRelativePath` with cross-platform `albumPath`.
- Keep `fileName` as the actual saved media file name.
- Map Android `albumPath` into the existing native `relativePath` save flow.
- Preserve Android public directory prefixes such as `Pictures`, `Movies`, `Music`, `Documents`, `Download`, `Downloads`, and `DCIM`.
- Add iOS PhotoKit folder hierarchy support with `PHCollectionList`.
- Use the last `albumPath` segment as the iOS album and parent segments as iOS folders.
- Add Dart validation for unsafe `albumPath` values.
- Add `SaveResult.savedUri`.
- Add `SaveResult.savedUris`.
- Mirror single-file `savedUri` into `savedUris`.
- Return saved URI from Android, iOS, and OHOS save flows.
- Return existing item URI for Android `skipIfExists` hits where resolvable.
- Update README and CHANGELOG.
- Add Dart MethodChannel tests for album path mapping, validation, and saved URI parsing.

## Breaking Changes

- Removed `androidRelativePath`.
- Use `albumPath` instead.

Migration examples:

```dart
// Before
androidRelativePath: 'Pictures/appName/images'

// After, recommended cross-platform form
albumPath: 'appName/images'

// After, Android-compatible public directory form
albumPath: 'Pictures/appName/images'
```

## Test result

https://github.com/user-attachments/assets/5bcf1c22-1ade-4c41-ac8a-4a700ba60669

